### PR TITLE
ignore 404 when deleting an API, fixes #469

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ from Dashboard to Kubernetes environment. [#481](https://github.com/TykTechnolog
 - Fixed user email format used in integration tests since e2e tests were failing after Tyk v4.0.6 was released [#510](https://github.com/TykTechnologies/tyk-operator/pull/510)
 - Fixed bug in linking logic of SubGraph CR and ApiDefinition CR [#522](https://github.com/TykTechnologies/tyk-operator/pull/522).
 - Operator was panicking when invalid certificate was provided [#529](https://github.com/TykTechnologies/tyk-operator/pull/529)
+- Operator was failing to remove finalizers from ApiDefinition that was already deleted in Dashboard
 
 ## [v0.11.0](https://github.com/TykTechnologies/tyk-operator/tree/v0.11.0)
 [Full Changelog](https://github.com/TykTechnologies/tyk-operator/compare/v0.10.0...v0.11.0)

--- a/controllers/apidefinition_controller.go
+++ b/controllers/apidefinition_controller.go
@@ -542,7 +542,9 @@ func (r *ApiDefinitionReconciler) delete(ctx context.Context, desired *tykv1alph
 		r.Log.Info("deleting api")
 
 		_, err = klient.Universal.Api().Delete(ctx, desired.Status.ApiID)
-		if err != nil {
+		if err != nil && err.Error() == "Resource not found" {
+			r.Log.Error(err, "ignoring not existing api on delete", "api_id", desired.Status.ApiID)
+		} else if err != nil {
 			r.Log.Error(err, "unable to delete api", "api_id", desired.Status.ApiID)
 			return 0, err
 		}


### PR DESCRIPTION
Ignore not-found error when attempting to delete an API.

## Related Issue
#469

## Motivation and Context
`ApiDefinition` `CR`s get stuck when API-definition has been deleted using the dashboard.

## Test Coverage For This Change
- Create an API-definition using `tyk-operator`
- Delete the API-definition using the dashboard
- Delete the API-definition using `tyk-operator`
- Verify that `tyk-operator` removed the api-definition `CR`

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If PRing from your fork, don't come from your `master`!
- [x] Make sure you are making a pull request against our **`master` branch** (left side). Also, it would be best if you started *your change* off *our latest `master`*.
- [x] Make sure you are updating [CHANGELOG.md](https://github.com/TykTechnologies/tyk-operator/blob/master/CHANGELOG.md) based on your changes.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] If you've changed API models, please update CRDs.
  - [ ] `make manifests`
  - [ ] `make helm`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [ ] `gofmt -s -w .`
  - [ ] `go vet ./...`
  - [ ] `golangci-lint run`
